### PR TITLE
remove Ruby 2.1.10, add Ruby 2.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.5.1
   - 2.4.3
   - 2.3.5
   - 2.2.8
-  - 2.1.10
 before_install: gem install bundler -v 1.16.2


### PR DESCRIPTION
* Ruby 2.1.10 だと, 依存するライブラリでエラーが発生する為 (https://travis-ci.org/inokappa/furikake/jobs/456605937)