### PR TITLE
Backlog の API キーを環境変数でも渡せるようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 vendor/
 .DS_Store
 test.*
+spec/tmp/furikake.yml.test

--- a/lib/furikake/report.rb
+++ b/lib/furikake/report.rb
@@ -10,6 +10,7 @@ module Furikake
     end
 
     def show
+      @params = read_furikake_yaml
       @params['backlog']['projects'].each do |p|
         header = insert_published_by(p['header'])
         footer = p['footer']
@@ -23,7 +24,8 @@ module Furikake
         footer = p['footer']
         document = generate(header, footer)
         p['wiki_contents'] = document
-        Furikake::Reporters::Backlog.new(p).publish
+        param = check_api_key(p)
+        Furikake::Reporters::Backlog.new(param).publish
       end
     end
 
@@ -36,6 +38,17 @@ module Furikake
 #{footer}
 EOS
       documents
+    end
+
+    def check_api_key(param)
+      if !param.has_key?(:api_key) or !param['api_key'].nil?
+        if !ENV['BACKLOG_API_KEY'].nil? or !ENV['BACKLOG_API_KEY'] == ''
+          param['api_key'] = ENV['BACKLOG_API_KEY'] 
+          return param
+        end
+        raise 'API キーを読み込むことが出来ませんでした.'
+      end
+      param
     end
 
     def insert_published_by(header)

--- a/lib/furikake/report.rb
+++ b/lib/furikake/report.rb
@@ -4,9 +4,7 @@ module Furikake
   class Report
     include Furikake::Config
 
-    def initialize
-      @resource = Furikake::Resource.generate
-    end
+    def initialize; end
 
     def show
       params = read_furikake_yaml
@@ -32,9 +30,10 @@ module Furikake
     private
 
     def generate(header, footer)
+      resource = Furikake::Resource.generate
       documents = <<"EOS"
 #{header}
-#{@resource}
+#{resource}
 #{footer}
 EOS
       documents

--- a/lib/furikake/report.rb
+++ b/lib/furikake/report.rb
@@ -5,13 +5,12 @@ module Furikake
     include Furikake::Config
 
     def initialize
-      @params = read_furikake_yaml
       @resource = Furikake::Resource.generate
     end
 
     def show
-      @params = read_furikake_yaml
-      @params['backlog']['projects'].each do |p|
+      params = read_furikake_yaml
+      params['backlog']['projects'].each do |p|
         header = insert_published_by(p['header'])
         footer = p['footer']
         puts generate(header, footer)
@@ -19,7 +18,8 @@ module Furikake
     end
 
     def publish
-      @params['backlog']['projects'].each do |p|
+      params = read_furikake_yaml
+      params['backlog']['projects'].each do |p|
         header = insert_published_by(p['header'])
         footer = p['footer']
         document = generate(header, footer)

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'Frikake::Report' do
+  before(:each) { @report = Furikake::Report.new }
+
+  it 'check check_api_key (api_key in param)' do
+    param = { 'api_key': 'xxxxx', 'foo': 'bar' }
+    actual = @report.send(:check_api_key, param)
+    expect(param).to eq(actual)
+  end
+
+  it 'check check_api_key (api_key not in param)' do
+    param = { 'foo': 'bar' }
+    expect{@report.send(:check_api_key, param)}.to raise_error(RuntimeError, 'API キーを読み込むことが出来ませんでした.')
+  end
+
+  it 'check check_api_key (api_key not in param but have environment)' do
+    ENV['BACKLOG_API_KEY'] = 'xxxxx'
+    param = { 'foo': 'bar' }
+    expect = { 'api_key': 'xxxxx', 'foo': 'bar' }
+    actual = @report.send(:check_api_key, param)
+    expect(param).to eq(actual)
+  end
+end

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
 describe 'Frikake::Report' do
-  before(:each) { @report = Furikake::Report.new }
+  before do
+    @report = Furikake::Report.new
+  end
 
   it 'check check_api_key (api_key in param)' do
     param = { 'api_key': 'xxxxx', 'foo': 'bar' }

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -7,9 +7,9 @@ describe 'Frikake::Resource' do
     allow(Furikake::Resource).to receive(:load_addons_resource_type).and_return(['test4', 'test5'])
   end
 
-  after do
-    File.delete('spec/tmp/furikake.yml.test')
-  end
+  # after do
+  #   File.delete('spec/tmp/furikake.yml.test')
+  # end
 
   it 'check load_resource_type' do
     actual = Furikake::Resource.load_resource_type


### PR DESCRIPTION
.furikake.yml 内だけで Backlog API キーを指定していると, .furikake.yml を git にコミットしたくなくなるので, 環境変数でも渡せるようにした.