### PR TITLE
Add stdout.sync for Docker logging.

### DIFF
--- a/lib/furikake/config.rb
+++ b/lib/furikake/config.rb
@@ -1,13 +1,14 @@
 module Furikake
   module Config
     def read_furikake_yaml
+      $stdout.sync = true
       begin
         YAML.load_file('.furikake.yml')
       rescue Errno::ENOENT
-        Logger.new(STDOUT).error('.furikake.yml が存在していません.')
+        Logger.new($stdout).error('.furikake.yml が存在していません.')
         exit 1
       rescue => ex
-        Logger.new(STDOUT).error('.furikake.yml の読み込みに失敗しました. ' + ex.message)
+        Logger.new($stdout).error('.furikake.yml の読み込みに失敗しました. ' + ex.message)
         exit 1
       end
     end

--- a/lib/furikake/monitor.rb
+++ b/lib/furikake/monitor.rb
@@ -3,7 +3,8 @@
 module Furikake
   class Monitor < Report
     def initialize(options)
-      @logger = Logger.new(STDOUT)
+      $stdout.sync = true
+      @logger = Logger.new($stdout)
       @flag_int = false
       @detach = options[:detach]
       @pid_file = options[:pid]

--- a/lib/furikake/report.rb
+++ b/lib/furikake/report.rb
@@ -5,7 +5,8 @@ module Furikake
     include Furikake::Config
 
     def initialize
-      @logger = Logger.new(STDOUT)
+      $stdout.sync = true
+      @logger = Logger.new($stdout)
     end
 
     def show

--- a/lib/furikake/resource.rb
+++ b/lib/furikake/resource.rb
@@ -70,7 +70,8 @@ module Furikake
     end
 
     def self.logger
-      Logger.new(STDOUT)
+      $stdout.sync = true
+      Logger.new($stdout)
     end
   end
 end


### PR DESCRIPTION
Docker コンテナで動かした際にログが出力されない (リアルタイムに出力されない) 為, 試しに `$stdout.sync = true` を追加した.